### PR TITLE
Invalid option(s) "transport_name"

### DIFF
--- a/src/Transport/Configuration/ConfigurationBuilder.php
+++ b/src/Transport/Configuration/ConfigurationBuilder.php
@@ -16,6 +16,7 @@ final class ConfigurationBuilder
     private ProducerConfigurationBuilder $producerBuilder;
 
     private const AVAILABLE_OPTIONS = [
+        'transport_name',
         'json_serialization',
         'consumer',
         'producer',


### PR DESCRIPTION
[InvalidArgumentException]
Invalid option(s) "transport_name" for transport "kafka". Available: "json_serialization", "consumer", "producer", "topics"

<img width="1025" height="121" alt="image" src="https://github.com/user-attachments/assets/d6adc9a7-f5c3-4912-968b-c68707a12e0d" />
